### PR TITLE
feat<SCRUM-34>: painel de acompanhamento dos tgs por parte do orientador, podendo visualizar o nome, titulo, tema, pendencias, progresso dos tgs

### DIFF
--- a/.idea/data_source_mapping.xml
+++ b/.idea/data_source_mapping.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="DataSourcePerFileMappings">
-    <file url="file://$APPLICATION_CONFIG_DIR$/consoles/db/e9c5ee52-d1f7-44ec-91fc-287320a12acc/console.sql" value="e9c5ee52-d1f7-44ec-91fc-287320a12acc" />
-  </component>
-</project>

--- a/src/main/java/br/edu/fatec/api/controller/orientador/PainelOrientadorController.java
+++ b/src/main/java/br/edu/fatec/api/controller/orientador/PainelOrientadorController.java
@@ -1,8 +1,16 @@
 package br.edu.fatec.api.controller.orientador;
 
+import br.edu.fatec.api.dto.PainelOrientadorRow;
+import br.edu.fatec.api.model.auth.User;
 import br.edu.fatec.api.nav.SceneManager;
+import br.edu.fatec.api.nav.Session;
+import br.edu.fatec.api.dao.JdbcPainelOrientadorDao;
+import javafx.collections.FXCollections;
+import javafx.collections.transformation.FilteredList;
 import javafx.fxml.FXML;
+import javafx.geometry.Insets;
 import javafx.scene.control.*;
+import javafx.scene.layout.HBox;
 
 public class PainelOrientadorController {
 
@@ -10,58 +18,135 @@ public class PainelOrientadorController {
     @FXML private Button btnPainel;
 
     // Filtros
-    @FXML private ChoiceBox<String> cbFiltroPrioridade;
     @FXML private TextField txtBuscaAluno;
 
     // Tabela
-    @FXML private TableView<?> tblPendencias;
-    @FXML private TableColumn<?,?> colAluno, colSecao, colPedido, colPrioridade, colAcoes;
+    @FXML private TableView<PainelOrientadorRow> tblPendencias;
+    @FXML private TableColumn<PainelOrientadorRow, String> colAluno, colTitulo, colTema, colVersao, colStatus;
+    @FXML private TableColumn<PainelOrientadorRow, Number> colValidadas, colPendencias;
+    @FXML private TableColumn<PainelOrientadorRow, PainelOrientadorRow> colProgresso;
+
+    private final JdbcPainelOrientadorDao dao = new JdbcPainelOrientadorDao();
+    private FilteredList<PainelOrientadorRow> filtered;
 
     @FXML
     private void initialize() {
-        // Destaca rota ativa na sidebar
         if (btnPainel != null && !btnPainel.getStyleClass().contains("active")) {
             btnPainel.getStyleClass().add("active");
         }
-
-        // Placeholders e filtros iniciais
         if (tblPendencias != null) {
             tblPendencias.setPlaceholder(new Label("Sem pendências no momento."));
         }
-        if (cbFiltroPrioridade != null) {
-            cbFiltroPrioridade.getItems().setAll("Todas", "Alta", "Média", "Baixa");
-            cbFiltroPrioridade.getSelectionModel().selectFirst();
-        }
+
+        // Bindings das colunas simples
+        colAluno.setCellValueFactory(c -> javafx.beans.binding.Bindings.createStringBinding(c.getValue()::getAluno));
+        colTitulo.setCellValueFactory(c -> javafx.beans.binding.Bindings.createStringBinding(c.getValue()::getTitulo));
+        colTema.setCellValueFactory(c -> javafx.beans.binding.Bindings.createStringBinding(c.getValue()::getTema));
+        colVersao.setCellValueFactory(c -> javafx.beans.binding.Bindings.createStringBinding(c.getValue()::getVersaoAtual));
+        colValidadas.setCellValueFactory(c -> javafx.beans.binding.Bindings.createIntegerBinding(c.getValue()::getTotalValidadas));
+        colPendencias.setCellValueFactory(c -> javafx.beans.binding.Bindings.createIntegerBinding(c.getValue()::getPendencias));
+
+        // Status com emoji (🔴🟡🟢)
+        colStatus.setCellFactory(col -> new TableCell<>() {
+            @Override
+            protected void updateItem(String status, boolean empty) {
+                super.updateItem(status, empty);
+                if (empty || status == null) {
+                    setText(null);
+                } else {
+                    String decorated = switch (status) {
+                        case "Concluído"     -> "Concluído ";
+                        case "Não avaliado"  -> "Não avaliado ";
+                        default               -> "Em andamento";
+                    };
+                    setText(decorated);
+                }
+            }
+        });
+        colStatus.setCellValueFactory(c -> javafx.beans.binding.Bindings.createStringBinding(c.getValue()::getStatus));
+
+        // Progresso: barra + label "XX%"
+        colProgresso.setCellValueFactory(c -> new javafx.beans.property.SimpleObjectProperty<>(c.getValue()));
+        colProgresso.setCellFactory(col -> new TableCell<>() {
+            private final ProgressBar bar = new ProgressBar(0);
+            private final Label lbl = new Label("0%");
+            private final HBox box = new HBox(8, bar, lbl);
+            {
+                box.setPadding(new Insets(2, 0, 2, 0));
+                bar.setPrefWidth(120);
+            }
+            @Override protected void updateItem(PainelOrientadorRow row, boolean empty) {
+                super.updateItem(row, empty);
+                if (empty || row == null) {
+                    setGraphic(null);
+                } else {
+                    double pct = row.getPercentual();
+                    double pct01 = Math.max(0, Math.min(1, pct / 100.0));
+                    bar.setProgress(pct01);
+                    lbl.setText(String.format("%.0f%%", pct));
+
+                    // Remove pseudo-classes anteriores
+                    bar.pseudoClassStateChanged(javafx.css.PseudoClass.getPseudoClass("low"), false);
+                    bar.pseudoClassStateChanged(javafx.css.PseudoClass.getPseudoClass("medium"), false);
+                    bar.pseudoClassStateChanged(javafx.css.PseudoClass.getPseudoClass("high"), false);
+
+                    // Define cor conforme progresso
+                    if (pct < 30) {
+                        bar.pseudoClassStateChanged(javafx.css.PseudoClass.getPseudoClass("low"), true);
+                    } else if (pct < 70) {
+                        bar.pseudoClassStateChanged(javafx.css.PseudoClass.getPseudoClass("medium"), true);
+                    } else {
+                        bar.pseudoClassStateChanged(javafx.css.PseudoClass.getPseudoClass("high"), true);
+                    }
+
+                    setGraphic(box);
+                }
+            }
+
+        });
+
+        // Carregar dados
+        User u = Session.getUser();
+        if (u == null) { SceneManager.go("login/Login.fxml"); return; }
+
+        var data = FXCollections.observableArrayList(dao.listar(u.getId()));
+        filtered = new FilteredList<>(data, r -> true);
+        tblPendencias.setItems(filtered);
+
+        // Filtro por nome do aluno
+        txtBuscaAluno.textProperty().addListener((obs, old, val) -> {
+            String q = val == null ? "" : val.trim().toLowerCase();
+            filtered.setPredicate(row ->
+                    q.isEmpty() || row.getAluno().toLowerCase().contains(q)
+            );
+        });
     }
 
     // ===== Ações da tabela/toolbar =====
     public void limparFiltros() {
-        if (cbFiltroPrioridade != null) cbFiltroPrioridade.getSelectionModel().selectFirst();
         if (txtBuscaAluno != null) txtBuscaAluno.clear();
-        // TODO: recarregar lista a partir do service
+        if (filtered != null) filtered.setPredicate(r -> true);
     }
 
     public void abrirEditor() {
-        // TODO: opcional: validar seleção antes de abrir
         SceneManager.go("orientador/Editor.fxml");
     }
 
     public void abrirChat() {
-        // TODO: opcional: enviar contexto do aluno selecionado
-        SceneManager.go("orientador/Chat.fxml");
+        SceneManager.go("orientador/Chat.fxml", c -> {
+            ChatOrientadorController ctrl = (ChatOrientadorController) c;
+            ctrl.onReady();
+        });
     }
 
     // ===== Navegação =====
     public void goHome(){ SceneManager.go("orientador/VisaoGeral.fxml"); }
     public void logout(){ SceneManager.go("login/Login.fxml"); }
-
     public void goVisaoGeral(){ SceneManager.go("orientador/VisaoGeral.fxml"); }
     public void goPainel(){ SceneManager.go("orientador/Painel.fxml"); }
-    public void goNotificacoes(){ SceneManager.go("orientador/Notificacoes.fxml"); }
     public void goEditor(){ SceneManager.go("orientador/Editor.fxml"); }
     public void goParecer(){ SceneManager.go("orientador/Parecer.fxml"); }
     public void goImportar(){ SceneManager.go("orientador/Importar.fxml"); }
-    // (ALTERADO POR MATHEUS - adicionado callback onReady)
     public void goChat() {
         SceneManager.go("orientador/Chat.fxml", c -> {
             ChatOrientadorController ctrl = (ChatOrientadorController) c;

--- a/src/main/java/br/edu/fatec/api/dao/JdbcPainelOrientadorDao.java
+++ b/src/main/java/br/edu/fatec/api/dao/JdbcPainelOrientadorDao.java
@@ -1,0 +1,86 @@
+package br.edu.fatec.api.dao;
+
+import br.edu.fatec.api.config.Database;
+import br.edu.fatec.api.dto.PainelOrientadorRow;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JdbcPainelOrientadorDao {
+
+    private static final String SQL =
+            """
+            SELECT
+              uOrientador.nome AS orientador,
+              uAluno.nome      AS aluno,
+              tg.titulo,
+              tg.tema,
+              tg.versao_atual,
+              COALESCE(sec.valid_sec, 0)
+            + COALESCE(ap.valid, 0)
+            + COALESCE(res.valid, 0) AS total_validadas,
+              9 - (COALESCE(sec.valid_sec, 0)
+            + COALESCE(ap.valid, 0)
+            + COALESCE(res.valid, 0)) AS pendencias,
+              CASE
+                WHEN 9 - (COALESCE(sec.valid_sec, 0)
+                       + COALESCE(ap.valid, 0)
+                       + COALESCE(res.valid, 0)) = 0 THEN 'Concluído'
+                WHEN 9 - (COALESCE(sec.valid_sec, 0)
+                       + COALESCE(ap.valid, 0)
+                       + COALESCE(res.valid, 0)) = 9 THEN 'Não avaliado'
+                ELSE 'Em andamento'
+              END AS status,
+              ROUND(((COALESCE(sec.valid_sec,0)
+                    + COALESCE(ap.valid,0)
+                    + COALESCE(res.valid,0)) / 9) * 100, 2) AS percentual_conclusao
+            FROM trabalhos_graduacao tg
+            INNER JOIN usuarios uAluno      ON uAluno.id       = tg.aluno_id
+            INNER JOIN usuarios uOrientador ON uOrientador.id  = tg.orientador_id
+            LEFT JOIN (
+              SELECT trabalho_id, versao, SUM(COALESCE(versao_validada,0)) AS valid_sec
+              FROM tg_secao
+              GROUP BY trabalho_id, versao
+            ) sec  ON sec.trabalho_id = tg.id AND sec.versao = tg.versao_atual
+            LEFT JOIN (
+              SELECT trabalho_id, versao,
+                     COALESCE(apresentacao_versao_validada,0)
+                   + COALESCE(consideracao_versao_validada,0) AS valid
+              FROM tg_apresentacao
+            ) ap   ON ap.trabalho_id = tg.id AND ap.versao = tg.versao_atual
+            LEFT JOIN (
+              SELECT trabalho_id, versao, COALESCE(versao_validada,0) AS valid
+              FROM tg_resumo
+            ) res  ON res.trabalho_id = tg.id AND res.versao = tg.versao_atual
+            WHERE uOrientador.id = ?
+            """;
+
+    public List<PainelOrientadorRow> listar(long orientadorId) {
+        List<PainelOrientadorRow> out = new ArrayList<>();
+        try (Connection con = Database.get();
+             PreparedStatement ps = con.prepareStatement(SQL)) {
+            ps.setLong(1, orientadorId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    out.add(new PainelOrientadorRow(
+                            rs.getString("orientador"),
+                            rs.getString("aluno"),
+                            rs.getString("titulo"),
+                            rs.getString("tema"),
+                            rs.getString("versao_atual"),
+                            rs.getInt("total_validadas"),
+                            rs.getInt("pendencias"),
+                            rs.getString("status"),
+                            rs.getDouble("percentual_conclusao")
+                    ));
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return out;
+    }
+}

--- a/src/main/java/br/edu/fatec/api/dto/PainelOrientadorRow.java
+++ b/src/main/java/br/edu/fatec/api/dto/PainelOrientadorRow.java
@@ -1,0 +1,37 @@
+package br.edu.fatec.api.dto;
+
+public class PainelOrientadorRow {
+    private final String orientador;
+    private final String aluno;
+    private final String titulo;
+    private final String tema;
+    private final String versaoAtual;
+    private final int totalValidadas;
+    private final int pendencias;
+    private final String status;           // "Não avaliado", "Em andamento", "Concluído"
+    private final double percentual;       // 0..100
+
+    public PainelOrientadorRow(String orientador, String aluno, String titulo, String tema,
+                               String versaoAtual, int totalValidadas, int pendencias,
+                               String status, double percentual) {
+        this.orientador = orientador;
+        this.aluno = aluno;
+        this.titulo = titulo;
+        this.tema = tema;
+        this.versaoAtual = versaoAtual;
+        this.totalValidadas = totalValidadas;
+        this.pendencias = pendencias;
+        this.status = status;
+        this.percentual = percentual;
+    }
+
+    public String getOrientador() { return orientador; }
+    public String getAluno() { return aluno; }
+    public String getTitulo() { return titulo; }
+    public String getTema() { return tema; }
+    public String getVersaoAtual() { return versaoAtual; }
+    public int getTotalValidadas() { return totalValidadas; }
+    public int getPendencias() { return pendencias; }
+    public String getStatus() { return status; }
+    public double getPercentual() { return percentual; }
+}

--- a/src/main/resources/application.css
+++ b/src/main/resources/application.css
@@ -446,3 +446,33 @@
 .status-badge { -fx-font-weight: bold; }
 .badge-ok { -fx-text-fill: #0a7a0a; }
 .badge-pendente { -fx-text-fill: #b35a00; }
+
+/* ===== Barra de Progresso colorida ===== */
+
+/* Reset e padding menor */
+.progress-bar {
+    -fx-accent: #4CAF50; /* verde padrão */
+    -fx-background-insets: 0;
+    -fx-padding: 1;
+}
+
+/* Vermelho até 30% */
+.progress-bar:low {
+    -fx-accent: #e74c3c; /* vermelho */
+}
+
+/* Amarelo entre 30% e 70% */
+.progress-bar:medium {
+    -fx-accent: #f1c40f; /* amarelo */
+}
+
+/* Verde acima de 70% */
+.progress-bar:high {
+    -fx-accent: #2ecc71; /* verde */
+}
+
+/* Label ao lado da barra */
+.table-cell .label {
+    -fx-font-weight: bold;
+    -fx-text-fill: #444;
+}

--- a/src/main/resources/views/orientador/Painel.fxml
+++ b/src/main/resources/views/orientador/Painel.fxml
@@ -23,12 +23,12 @@
         <padding><Insets top="16.0" right="16.0" bottom="16.0" left="16.0"/></padding>
 
         <!-- Sidebar -->
-        <VBox prefWidth="240.0" spacing="8.0" styleClass="sidebar">
+        <VBox minWidth="240.0" spacing="8.0" styleClass="sidebar">
             <Label styleClass="sidebar-title" text="Orientador"/>
             <Label styleClass="sidebar-group" text="GERAL"/>
             <Button alignment="BASELINE_LEFT" maxWidth="1.7976931348623157E308"
                     onAction="#goVisaoGeral" styleClass="sidebar-link" text="Visão Geral"/>
-            <Button alignment="BASELINE_LEFT" maxWidth="1.7976931348623157E308"
+            <Button fx:id="btnPainel" alignment="BASELINE_LEFT" maxWidth="1.7976931348623157E308"
                     onAction="#goPainel" styleClass="sidebar-link" text="Painel"/>
 
             <Label styleClass="sidebar-group" text="FERRAMENTAS"/>
@@ -47,14 +47,13 @@
             <!-- Título -->
             <VBox spacing="6.0">
                 <Label styleClass="title" text="Orientador — Painel de Pendências"/>
-                <Label styleClass="subtitle" text="Acompanhe pedidos por aluno, prioridade e ação recomendada."/>
+                <Label styleClass="subtitle" text="Acompanhe o progresso de cada aluno na versão atual."/>
             </VBox>
 
-            <!-- Filtros (opcional simples) -->
+            <!-- Filtros simples -->
             <HBox spacing="8.0" alignment="CENTER_LEFT">
-                <Label text="Filtrar:"/>
-                <ChoiceBox fx:id="cbFiltroPrioridade"/>
-                <TextField fx:id="txtBuscaAluno" promptText="Buscar aluno..."/>
+                <Label text="Buscar:"/>
+                <TextField fx:id="txtBuscaAluno" promptText="Nome do aluno..."/>
                 <Region HBox.hgrow="ALWAYS"/>
                 <Button text="Limpar" onAction="#limparFiltros"/>
             </HBox>
@@ -62,11 +61,14 @@
             <!-- Tabela -->
             <TableView fx:id="tblPendencias" VBox.vgrow="ALWAYS">
                 <columns>
-                    <TableColumn fx:id="colAluno" text="Aluno" prefWidth="180"/>
-                    <TableColumn fx:id="colSecao" text="Seção" prefWidth="160"/>
-                    <TableColumn fx:id="colPedido" text="Pedido" prefWidth="300"/>
-                    <TableColumn fx:id="colPrioridade" text="Prioridade" prefWidth="120"/>
-                    <TableColumn fx:id="colAcoes" text="Ações" prefWidth="160"/>
+                    <TableColumn fx:id="colAluno" text="Aluno" prefWidth="200"/>
+                    <TableColumn fx:id="colTitulo" text="Título" prefWidth="220"/>
+                    <TableColumn fx:id="colTema" text="Tema" prefWidth="220"/>
+                    <TableColumn fx:id="colVersao" text="Versão" prefWidth="90"/>
+                    <TableColumn fx:id="colValidadas" text="Validadas" prefWidth="110"/>
+                    <TableColumn fx:id="colPendencias" text="Pendências" prefWidth="110"/>
+                    <TableColumn fx:id="colStatus" text="Status" prefWidth="140"/>
+                    <TableColumn fx:id="colProgresso" text="Progresso" prefWidth="180"/>
                 </columns>
             </TableView>
 


### PR DESCRIPTION
## feat(orientador): painel com progresso por aluno, status visual e busca

### Resumo
Implementa o **Painel do Orientador** exibindo, por aluno, os KPIs da versão atual:
- Validadas / Pendências (base 9 validações)
- Percentual de conclusão com **barra de progresso**
- **Status visual**: Não avaliado 🔴 | Em andamento 🟡 | Concluído 🟢
- Filtro rápido por nome do aluno

### Principais mudanças
- **FXML**: remodelo da tabela (`Aluno`, `Título`, `Tema`, `Versão`, `Validadas`, `Pendências`, `Status`, `Progresso`).
  > Removida a coluna **Ações** conforme requisito.
- **Controller** (`PainelOrientadorController`):
    - Binding das colunas
    - Célula customizada: **ProgressBar + %** com cores (low/medium/high)
    - Filtro de busca por aluno
- **DAO** (`JdbcPainelOrientadorDao`): query idêntica à validada em SQL, parametrizada por `orientador_id`.
- **DTO** (`PainelOrientadorRow`): transporte dos campos da consulta.
- **CSS** (`application.css`): pseudo-classes para colorir progresso:
    - `<30%` vermelho (`:low`)
    - `30–70%` amarelo (`:medium`)
    - `≥70%` verde (`:high`)

### Testes manuais
- Lista popula corretamente para `orientador_id` logado.
- Percentual e pendências batem com os dados do banco.
- Status muda conforme pendências (0, 1..8, 9).
- Busca filtra por **nome do aluno**.
- Sem regressão na navegação/estilos.

### Impacto
- Apenas UI do orientador; sem breaking changes.
- Query otimizada via `LEFT JOIN` + `COALESCE`; sem multiplicação de linhas.

### Próximos passos (opcional)
- Ordenar por **pendências desc** por padrão.
- Botões “Ir ao Editor/Chat” por linha (se requisitado futuramente).
- Paginação quando nº de alunos crescer.

---
