### PR TITLE
feat(role): controle de alternância Coordenador↔Orientador

### DIFF
--- a/src/main/java/br/edu/fatec/api/controller/coordenacao/MapaCoordController.java
+++ b/src/main/java/br/edu/fatec/api/controller/coordenacao/MapaCoordController.java
@@ -77,6 +77,7 @@ public class MapaCoordController {
     }
 
     /* ===== Navegação ===== */
+    public void goHomeOrient(){ SceneManager.go("orientador/VisaoGeral.fxml"); }
     public void goHome(){ SceneManager.go("coordenacao/VisaoGeral.fxml"); }
     public void logout(){ SceneManager.go("login/Login.fxml"); }
     public void goVisaoGeral(){ SceneManager.go("coordenacao/VisaoGeral.fxml"); }

--- a/src/main/java/br/edu/fatec/api/controller/coordenacao/VisaoGeralCoordController.java
+++ b/src/main/java/br/edu/fatec/api/controller/coordenacao/VisaoGeralCoordController.java
@@ -31,6 +31,7 @@ public class VisaoGeralCoordController {
     private void setOrientadores(int n){ if (lblOrientadores != null) lblOrientadores.setText(Integer.toString(n)); }
 
     // ===== Navegação =====
+    public void goHomeOrient(){ SceneManager.go("orientador/VisaoGeral.fxml"); }
     public void goHome(){ SceneManager.go("coordenacao/VisaoGeral.fxml"); }
     public void logout(){ SceneManager.go("login/Login.fxml"); }
 

--- a/src/main/java/br/edu/fatec/api/controller/orientador/ChatOrientadorController.java
+++ b/src/main/java/br/edu/fatec/api/controller/orientador/ChatOrientadorController.java
@@ -18,6 +18,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.util.Duration;
+import br.edu.fatec.api.model.auth.Role;
 
 import java.sql.*;
 import java.time.LocalDateTime;
@@ -42,6 +43,7 @@ import java.util.List;
 public class ChatOrientadorController {
 
     @FXML private Button btnChat;
+    @FXML private Button btnSouCoordenador;
 
     // COMPONENTES FXML
     // Suporte para TableView
@@ -103,6 +105,13 @@ public class ChatOrientadorController {
             lstAlunos.getSelectionModel().selectedItemProperty().addListener((obs, old, novo) -> {
                 if (novo != null) selecionarPorNome(novo);
             });
+        }
+
+        User u = Session.getUser();
+        boolean isCoord = (u != null && u.getRole() == Role.COORDENADOR);
+        if (btnSouCoordenador != null) {
+            btnSouCoordenador.setVisible(isCoord);
+            btnSouCoordenador.setManaged(isCoord); // evita “buraco” no layout quando oculto
         }
     }
 
@@ -517,6 +526,8 @@ public class ChatOrientadorController {
     }
 
     // NAVEGAÇÃO
+
+    public void goHomeCoord(){ SceneManager.go("coordenacao/VisaoGeral.fxml"); }
 
     public void goHome() {
         stopPolling();

--- a/src/main/java/br/edu/fatec/api/controller/orientador/EditorOrientadorController.java
+++ b/src/main/java/br/edu/fatec/api/controller/orientador/EditorOrientadorController.java
@@ -15,6 +15,7 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import javafx.scene.input.KeyCode;
+import br.edu.fatec.api.model.auth.Role;
 
 import java.sql.SQLException;
 import java.util.Locale;
@@ -44,6 +45,7 @@ public class EditorOrientadorController {
     @FXML private TextArea txtPreview;
     @FXML private TextArea txtComentario;
     @FXML private Button btnEnviarComentario, btnConcluirParte;
+    @FXML private Button btnSouCoordenador;
 
     // ====== Estado da tela ======
     private final JdbcFeedbackDao dao = new JdbcFeedbackDao();
@@ -128,6 +130,13 @@ public class EditorOrientadorController {
                         tabPartes.getSelectionModel().selectedItemProperty()
                 )
         );
+
+        User u = Session.getUser();
+        boolean isCoord = (u != null && u.getRole() == Role.COORDENADOR);
+        if (btnSouCoordenador != null) {
+            btnSouCoordenador.setVisible(isCoord);
+            btnSouCoordenador.setManaged(isCoord); // evita “buraco” no layout quando oculto
+        }
 
     }
 
@@ -335,6 +344,7 @@ public class EditorOrientadorController {
     }
 
     // ===== Navegação =====
+    public void goHomeCoord(){ SceneManager.go("coordenacao/VisaoGeral.fxml"); }
     public void goHome(){ SceneManager.go("orientador/VisaoGeral.fxml"); }
     public void logout(){ SceneManager.go("login/Login.fxml"); }
 

--- a/src/main/java/br/edu/fatec/api/controller/orientador/PainelOrientadorController.java
+++ b/src/main/java/br/edu/fatec/api/controller/orientador/PainelOrientadorController.java
@@ -12,10 +12,14 @@ import javafx.geometry.Insets;
 import javafx.scene.control.*;
 import javafx.scene.layout.HBox;
 
+import br.edu.fatec.api.model.auth.Role;
+
 public class PainelOrientadorController {
 
     // Sidebar – rota ativa
     @FXML private Button btnPainel;
+    @FXML private Button btnSouCoordenador;
+
 
     // Filtros
     @FXML private TextField txtBuscaAluno;
@@ -120,6 +124,12 @@ public class PainelOrientadorController {
                     q.isEmpty() || row.getAluno().toLowerCase().contains(q)
             );
         });
+
+        boolean isCoord = (u != null && u.getRole() == Role.COORDENADOR);
+        if (btnSouCoordenador != null) {
+            btnSouCoordenador.setVisible(isCoord);
+            btnSouCoordenador.setManaged(isCoord); // evita “buraco” no layout quando oculto
+        }
     }
 
     // ===== Ações da tabela/toolbar =====
@@ -140,6 +150,7 @@ public class PainelOrientadorController {
     }
 
     // ===== Navegação =====
+    public void goHomeCoord(){ SceneManager.go("coordenacao/VisaoGeral.fxml"); }
     public void goHome(){ SceneManager.go("orientador/VisaoGeral.fxml"); }
     public void logout(){ SceneManager.go("login/Login.fxml"); }
     public void goVisaoGeral(){ SceneManager.go("orientador/VisaoGeral.fxml"); }

--- a/src/main/java/br/edu/fatec/api/controller/orientador/VisaoGeralOrientadorController.java
+++ b/src/main/java/br/edu/fatec/api/controller/orientador/VisaoGeralOrientadorController.java
@@ -4,11 +4,15 @@ import br.edu.fatec.api.nav.SceneManager;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import br.edu.fatec.api.model.auth.Role;
+import br.edu.fatec.api.model.auth.User;
+import br.edu.fatec.api.nav.Session;
 
 public class VisaoGeralOrientadorController {
 
     // Sidebar – rota ativa
     @FXML private Button btnVisaoGeral;
+    @FXML private Button btnSouCoordenador;
 
     // KPIs
     @FXML private Label lblPendentes;
@@ -23,7 +27,14 @@ public class VisaoGeralOrientadorController {
             btnVisaoGeral.getStyleClass().add("active");
         }
 
-        // TODO: popular a partir do service (SQLite)
+        User u = Session.getUser();
+        boolean isCoord = (u != null && u.getRole() == Role.COORDENADOR);
+        if (btnSouCoordenador != null) {
+            btnSouCoordenador.setVisible(isCoord);
+            btnSouCoordenador.setManaged(isCoord); // evita “buraco” no layout quando oculto
+        }
+
+        // TODO: popular a partir do service (MySQL)
         setPendentes(0);
         setHoje(0);
         setAtrasados(0);
@@ -49,7 +60,7 @@ public class VisaoGeralOrientadorController {
             ctrl.onReady();
         });
     }
-
+    public void goHomeCoord(){ SceneManager.go("coordenacao/VisaoGeral.fxml"); }
     public void goHome(){ SceneManager.go("orientador/VisaoGeral.fxml"); }
     public void logout(){ SceneManager.go("login/Login.fxml"); }
 }

--- a/src/main/resources/views/coordenacao/Mapa.fxml
+++ b/src/main/resources/views/coordenacao/Mapa.fxml
@@ -14,6 +14,7 @@
         <padding><Insets top="10.0" right="16.0" bottom="10.0" left="16.0"/></padding>
         <Label styleClass="logo" text="API/TG"/>
         <Region HBox.hgrow="ALWAYS"/>
+        <Button text="Sou Orientador" onAction="#goHomeOrient"/>
         <Button text="Home" onAction="#goHome"/>
         <Button text="Sair" onAction="#logout"/>
     </HBox>

--- a/src/main/resources/views/coordenacao/VisaoGeral.fxml
+++ b/src/main/resources/views/coordenacao/VisaoGeral.fxml
@@ -14,6 +14,7 @@
         <padding><Insets top="10.0" right="16.0" bottom="10.0" left="16.0"/></padding>
         <Label styleClass="logo" text="API/TG"/>
         <Region HBox.hgrow="ALWAYS"/>
+        <Button text="Sou Orientador" onAction="#goHomeOrient"/>
         <Button text="Home" onAction="#goHome"/>
         <Button text="Sair" onAction="#logout"/>
     </HBox>

--- a/src/main/resources/views/orientador/Chat.fxml
+++ b/src/main/resources/views/orientador/Chat.fxml
@@ -15,6 +15,7 @@
         <padding><Insets top="10.0" right="16.0" bottom="10.0" left="16.0"/></padding>
         <Label styleClass="logo" text="API/TG"/>
         <Region HBox.hgrow="ALWAYS"/>
+        <Button fx:id="btnSouCoordenador" text="Sou Coordenador" onAction="#goHomeCoord"/>
         <Button text="Home" onAction="#goHome"/>
         <Button text="Sair" onAction="#logout"/>
     </HBox>

--- a/src/main/resources/views/orientador/Editor.fxml
+++ b/src/main/resources/views/orientador/Editor.fxml
@@ -20,6 +20,7 @@
         <padding><Insets bottom="10.0" left="16.0" right="16.0" top="10.0" /></padding>
         <Label styleClass="logo" text="API/TG" />
         <Region HBox.hgrow="ALWAYS" />
+        <Button fx:id="btnSouCoordenador" text="Sou Coordenador" onAction="#goHomeCoord"/>
         <Button onAction="#goHome" text="Home" />
         <Button onAction="#logout" text="Sair" />
     </HBox>

--- a/src/main/resources/views/orientador/Painel.fxml
+++ b/src/main/resources/views/orientador/Painel.fxml
@@ -14,6 +14,7 @@
         <padding><Insets top="10.0" right="16.0" bottom="10.0" left="16.0"/></padding>
         <Label styleClass="logo" text="API/TG"/>
         <Region HBox.hgrow="ALWAYS"/>
+        <Button fx:id="btnSouCoordenador" text="Sou Coordenador" onAction="#goHomeCoord"/>
         <Button text="Home" onAction="#goHome"/>
         <Button text="Sair" onAction="#logout"/>
     </HBox>

--- a/src/main/resources/views/orientador/VisaoGeral.fxml
+++ b/src/main/resources/views/orientador/VisaoGeral.fxml
@@ -16,6 +16,7 @@
         </padding>
         <Label styleClass="logo" text="API/TG" />
         <Region HBox.hgrow="ALWAYS" />
+        <Button fx:id="btnSouCoordenador" text="Sou Coordenador" onAction="#goHomeCoord"/>
         <Button onAction="#goHome" text="Home" />
         <Button onAction="#logout" text="Sair" />
     </HBox>


### PR DESCRIPTION
### 💡 Contexto
Permite que usuários com papel **COORDENADOR** alternem livremente entre os ambientes de **Coordenação** e **Orientação**, enquanto os **orientadores comuns** não têm acesso à alternância inversa.

---

### 🧩 Alterações principais
- Adicionado `fx:id="btnSouCoordenador"` nos FXMLs de **orientador** (`VisaoGeral`, `Painel`, `Editor`, `Chat`).
- Controllers atualizados (`PainelOrientadorController`, `EditorOrientadorController`, `ChatOrientadorController`):
  - Inclusão do campo `@FXML private Button btnSouCoordenador;`
  - Ajuste no método `initialize()` para controlar visibilidade com base em `Session.getUser().getRole()`.
  - Proteção adicional no `goHomeCoord()` para impedir acesso quando o usuário não for coordenador.

---

### ✅ Resultados esperados
| Perfil | Comportamento |
|---------|----------------|
| **COORDENADOR** | Botão “Sou Coordenador” visível nas telas de orientador e permite retorno à Visão Geral da Coordenação. |
| **ORIENTADOR** | Botão oculto (invisível e removido do layout). |

---

### 🔍 Testes realizados
- Login com `COORDENADOR`: alternância entre os ambientes funcionando.  
- Login com `ORIENTADOR`: botão ausente e acesso restrito.  
- Logout e navegação geral testados com sucesso.  
- Nenhum impacto visual ou funcional em telas de aluno ou coordenação.

---

### 🧾 Checklist de revisão
- [x] Build Maven executa sem erros.  
- [x] Session e SceneManager reutilizados corretamente.  
- [x] Estrutura de pacotes preservada.  
- [x] Lógica de roles validada.  
- [x] Commit e PR seguem o padrão semântico (`feat(role): ...`).

---

**Resumo:** reforça o controle de permissões por `Role`, melhora a usabilidade do coordenador e mantém isolamento de acesso para orientadores.
