### PR TITLE
fix<untracked>: correção preview de históricos após mudança para JDK 21

### DIFF
--- a/src/main/java/br/edu/fatec/api/controller/aluno/HistoricoAlunoController.java
+++ b/src/main/java/br/edu/fatec/api/controller/aluno/HistoricoAlunoController.java
@@ -9,7 +9,6 @@ import br.edu.fatec.api.nav.Session;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import javafx.scene.layout.VBox;
-import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 
 import java.sql.SQLException;

--- a/src/main/java/br/edu/fatec/api/controller/aluno/HistoricoAlunoController.java
+++ b/src/main/java/br/edu/fatec/api/controller/aluno/HistoricoAlunoController.java
@@ -14,6 +14,11 @@ import javafx.scene.web.WebView;
 
 import java.sql.SQLException;
 import java.time.format.DateTimeFormatter;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import java.util.Collections;
 import java.util.List;
 
 public class HistoricoAlunoController extends BaseController {
@@ -29,8 +34,18 @@ public class HistoricoAlunoController extends BaseController {
     private final JdbcVersoesTrabalhoDao dao = new JdbcVersoesTrabalhoDao();
     private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
 
+    // Ferramentas do Flexmark (Java)
+    private Parser parser;
+    private HtmlRenderer renderer;
+
     @FXML
     private void initialize() {
+        // --- CONFIGURAÇÃO FLEXMARK ---
+        MutableDataSet options = new MutableDataSet();
+        options.set(Parser.EXTENSIONS, Collections.singletonList(TablesExtension.create()));
+
+        this.parser = Parser.builder(options).build();
+        this.renderer = HtmlRenderer.builder(options).build();
         if (btnToggleSidebar != null) {
             btnToggleSidebar.setText("☰");
         }
@@ -120,109 +135,90 @@ public class HistoricoAlunoController extends BaseController {
     }
 
     private void renderMarkdown(String markdown) {
-        WebEngine engine = webPreview.getEngine();
-        
-        String escapedMarkdown = escapeForJavaScript(markdown);
-        
-        // HTML template com estilização similar ao markdownlivepreview.com
-        String html = String.format("""
-                <!DOCTYPE html>
-                <html>
-                <head>
-                    <meta charset="UTF-8">
-                    <style>
-                        body {
-                            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-                            line-height: 1.6;
-                            padding: 20px;
-                            color: #333;
-                            background: #fff;
-                            max-width: 100%%;
-                            margin: 0 auto;
-                        }
-                        h1, h2, h3, h4, h5, h6 {
-                            margin-top: 24px;
-                            margin-bottom: 16px;
-                            font-weight: 600;
-                            line-height: 1.25;
-                        }
-                        h1 { font-size: 2em; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; }
-                        h2 { font-size: 1.5em; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; }
-                        h3 { font-size: 1.25em; }
-                        h4 { font-size: 1em; }
-                        h5 { font-size: 0.875em; }
-                        h6 { font-size: 0.85em; color: #6a737d; }
-                        p { margin-bottom: 16px; }
-                        ul, ol { padding-left: 2em; margin-bottom: 16px; }
-                        li { margin-bottom: 4px; }
-                        code {
-                            background-color: #f6f8fa;
-                            border-radius: 3px;
-                            padding: 2px 4px;
-                            font-family: 'Courier New', Courier, monospace;
-                            font-size: 85%%;
-                        }
-                        pre {
-                            background-color: #f6f8fa;
-                            border-radius: 3px;
-                            padding: 16px;
-                            overflow: auto;
-                            margin-bottom: 16px;
-                        }
-                        pre code {
-                            background: none;
-                            padding: 0;
-                        }
-                        blockquote {
-                            padding: 0 1em;
-                            color: #6a737d;
-                            border-left: 0.25em solid #dfe2e5;
-                            margin: 0 0 16px 0;
-                        }
-                        table {
-                            border-collapse: collapse;
-                            width: 100%%;
-                            margin-bottom: 16px;
-                        }
-                        table th, table td {
-                            border: 1px solid #dfe2e5;
-                            padding: 6px 13px;
-                        }
-                        table th {
-                            background-color: #f6f8fa;
-                            font-weight: 600;
-                        }
-                        table tr:nth-child(2n) {
-                            background-color: #f6f8fa;
-                        }
-                        hr {
-                            border: 0;
-                            border-top: 1px solid #eaecef;
-                            margin: 24px 0;
-                        }
-                        a {
-                            color: #0366d6;
-                            text-decoration: none;
-                        }
-                        a:hover {
-                            text-decoration: underline;
-                        }
-                        strong { font-weight: 600; }
-                        em { font-style: italic; }
-                    </style>
-                    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-                </head>
-                <body>
-                    <div id="content"></div>
-                    <script>
-                        const markdown = `%s`;
-                        document.getElementById('content').innerHTML = marked.parse(markdown);
-                    </script>
-                </body>
-                </html>
-                """, escapedMarkdown);
-        
-        engine.loadContent(html);
+        if (webPreview == null) return;
+
+        // 1. Converte Markdown para HTML usando Java (Flexmark)
+        String md = (markdown == null) ? "" : markdown;
+        String htmlBody = renderer.render(parser.parse(md));
+
+        // 2. Monta o HTML final (CORRIGIDO: Note os '%%' no CSS)
+        String htmlCompleto = """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="UTF-8">
+                <style>
+                    body {
+                        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+                        font-size: 14px;
+                        line-height: 1.6;
+                        color: #24292e;
+                        background-color: #ffffff;
+                        padding: 20px;
+                    }
+                    h1, h2, h3, h4, h5, h6 {
+                        margin-top: 24px;
+                        margin-bottom: 16px;
+                        font-weight: 600;
+                        line-height: 1.25;
+                        border-bottom: 1px solid #eaecef;
+                        padding-bottom: 0.3em;
+                    }
+                    p { margin-bottom: 16px; }
+                    code {
+                        padding: 0.2em 0.4em;
+                        margin: 0;
+                        font-size: 85%%; /* Corrigido: %% */
+                        background-color: #f6f8fa;
+                        border-radius: 3px;
+                        font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+                    }
+                    pre {
+                        padding: 16px;
+                        overflow: auto;
+                        font-size: 85%%; /* Corrigido: %% */
+                        line-height: 1.45;
+                        background-color: #f6f8fa;
+                        border-radius: 3px;
+                    }
+                    pre code {
+                        background-color: transparent;
+                        padding: 0;
+                    }
+                    blockquote {
+                        padding: 0 1em;
+                        color: #6a737d;
+                        border-left: 0.25em solid #dfe2e5;
+                        margin: 0 0 16px 0;
+                    }
+                    table {
+                        border-collapse: collapse;
+                        width: 100%%; /* Corrigido: %% */
+                        margin-bottom: 16px;
+                    }
+                    table th, table td {
+                        padding: 6px 13px;
+                        border: 1px solid #dfe2e5;
+                    }
+                    table th {
+                        font-weight: 600;
+                        background-color: #f6f8fa;
+                    }
+                    tr:nth-child(2n) {
+                        background-color: #f8f8f8;
+                    }
+                    ul, ol { padding-left: 2em; margin-bottom: 16px; }
+                    hr { height: 0.25em; padding: 0; margin: 24px 0; background-color: #e1e4e8; border: 0; }
+                </style>
+            </head>
+            <body>
+                %s
+            </body>
+            </html>
+            """.formatted(htmlBody);
+
+        // 3. Carrega no WebView
+        webPreview.getEngine().loadContent(htmlCompleto);
     }
 
     private String escapeForJavaScript(String str) {

--- a/src/main/java/br/edu/fatec/api/controller/coordenacao/HistoricoCoordController.java
+++ b/src/main/java/br/edu/fatec/api/controller/coordenacao/HistoricoCoordController.java
@@ -20,6 +20,11 @@ import javafx.scene.web.WebView;
 
 import java.sql.SQLException;
 import java.time.format.DateTimeFormatter;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import java.util.Collections;
 import java.util.List;
 
 public class HistoricoCoordController extends BaseController {
@@ -29,7 +34,6 @@ public class HistoricoCoordController extends BaseController {
     @FXML private TextField txtBuscaAluno;
 
     @FXML private ListView<VersaoHistoricoDTO> listVersions;
-    @FXML private TextArea txtMarkdownSource;
     @FXML private WebView webPreview;
     @FXML private Label lblAlunoSelecionado;
     @FXML private Label lblVersaoSelecionada;
@@ -45,9 +49,18 @@ public class HistoricoCoordController extends BaseController {
     private Long orientadorId;
     private Long alunoSelecionadoId;
     private Long trabalhoIdSelecionado;
+    // Ferramentas do Flexmark (Java)
+    private Parser parser;
+    private HtmlRenderer renderer;
 
     @FXML
     private void initialize() {
+        // --- CONFIGURAÇÃO FLEXMARK ---
+        MutableDataSet options = new MutableDataSet();
+        options.set(Parser.EXTENSIONS, Collections.singletonList(TablesExtension.create()));
+
+        this.parser = Parser.builder(options).build();
+        this.renderer = HtmlRenderer.builder(options).build();
         if (btnToggleSidebar != null) {
             btnToggleSidebar.setText("☰");
         }
@@ -188,96 +201,95 @@ public class HistoricoCoordController extends BaseController {
         lblVersaoSelecionada.setText(versao.versao());
         lblDataEnvio.setText(versao.createdAt().format(dateFormatter));
 
-        // Exibir markdown
-        txtMarkdownSource.setText(versao.conteudoMd());
-
         // Renderizar preview
         renderMarkdown(versao.conteudoMd());
     }
 
     private void renderMarkdown(String markdown) {
-        WebEngine engine = webPreview.getEngine();
+        if (webPreview == null) return;
 
-        String escapedMarkdown = escapeForJavaScript(markdown);
+        // 1. Converte Markdown para HTML usando Java (Flexmark)
+        String md = (markdown == null) ? "" : markdown;
+        String htmlBody = renderer.render(parser.parse(md));
 
-        String html = String.format("""
-                <!DOCTYPE html>
-                <html>
-                <head>
-                    <meta charset="UTF-8">
-                    <style>
-                        body {
-                            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-                            line-height: 1.6;
-                            padding: 20px;
-                            color: #333;
-                            background: #fff;
-                            max-width: 100%%;
-                            margin: 0 auto;
-                        }
-                        h1, h2, h3, h4, h5, h6 {
-                            margin-top: 24px;
-                            margin-bottom: 16px;
-                            font-weight: 600;
-                            line-height: 1.25;
-                        }
-                        h1 { font-size: 2em; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; }
-                        h2 { font-size: 1.5em; border-bottom: 1px solid #eaecef; padding-bottom: 0.3em; }
-                        h3 { font-size: 1.25em; }
-                        p { margin-bottom: 16px; }
-                        ul, ol { padding-left: 2em; margin-bottom: 16px; }
-                        code {
-                            background-color: #f6f8fa;
-                            border-radius: 3px;
-                            padding: 2px 4px;
-                            font-family: 'Courier New', Courier, monospace;
-                            font-size: 85%%;
-                        }
-                        pre {
-                            background-color: #f6f8fa;
-                            border-radius: 3px;
-                            padding: 16px;
-                            overflow: auto;
-                            margin-bottom: 16px;
-                        }
-                        table {
-                            border-collapse: collapse;
-                            width: 100%%;
-                            margin-bottom: 16px;
-                        }
-                        table th, table td {
-                            border: 1px solid #dfe2e5;
-                            padding: 6px 13px;
-                        }
-                        table th {
-                            background-color: #f6f8fa;
-                            font-weight: 600;
-                        }
-                        strong { font-weight: 600; }
-                    </style>
-                    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-                </head>
-                <body>
-                    <div id="content"></div>
-                    <script>
-                        const markdown = `%s`;
-                        document.getElementById('content').innerHTML = marked.parse(markdown);
-                    </script>
-                </body>
-                </html>
-                """, escapedMarkdown);
+        // 2. Monta o HTML final (CORRIGIDO: Note os '%%' no CSS)
+        String htmlCompleto = """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="UTF-8">
+                <style>
+                    body {
+                        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+                        font-size: 14px;
+                        line-height: 1.6;
+                        color: #24292e;
+                        background-color: #ffffff;
+                        padding: 20px;
+                    }
+                    h1, h2, h3, h4, h5, h6 {
+                        margin-top: 24px;
+                        margin-bottom: 16px;
+                        font-weight: 600;
+                        line-height: 1.25;
+                        border-bottom: 1px solid #eaecef;
+                        padding-bottom: 0.3em;
+                    }
+                    p { margin-bottom: 16px; }
+                    code {
+                        padding: 0.2em 0.4em;
+                        margin: 0;
+                        font-size: 85%%; /* Corrigido: %% */
+                        background-color: #f6f8fa;
+                        border-radius: 3px;
+                        font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+                    }
+                    pre {
+                        padding: 16px;
+                        overflow: auto;
+                        font-size: 85%%; /* Corrigido: %% */
+                        line-height: 1.45;
+                        background-color: #f6f8fa;
+                        border-radius: 3px;
+                    }
+                    pre code {
+                        background-color: transparent;
+                        padding: 0;
+                    }
+                    blockquote {
+                        padding: 0 1em;
+                        color: #6a737d;
+                        border-left: 0.25em solid #dfe2e5;
+                        margin: 0 0 16px 0;
+                    }
+                    table {
+                        border-collapse: collapse;
+                        width: 100%%; /* Corrigido: %% */
+                        margin-bottom: 16px;
+                    }
+                    table th, table td {
+                        padding: 6px 13px;
+                        border: 1px solid #dfe2e5;
+                    }
+                    table th {
+                        font-weight: 600;
+                        background-color: #f6f8fa;
+                    }
+                    tr:nth-child(2n) {
+                        background-color: #f8f8f8;
+                    }
+                    ul, ol { padding-left: 2em; margin-bottom: 16px; }
+                    hr { height: 0.25em; padding: 0; margin: 24px 0; background-color: #e1e4e8; border: 0; }
+                </style>
+            </head>
+            <body>
+                %s
+            </body>
+            </html>
+            """.formatted(htmlBody);
 
-        engine.loadContent(html);
-    }
-
-    private String escapeForJavaScript(String str) {
-        if (str == null) return "";
-        return str.replace("\\", "\\\\")
-                .replace("`", "\\`")
-                .replace("$", "\\$")
-                .replace("\r\n", "\\n")
-                .replace("\n", "\\n")
-                .replace("\r", "\\n");
+        // 3. Carrega no WebView
+        webPreview.getEngine().loadContent(htmlCompleto);
     }
 
     // Navegação

--- a/src/main/java/br/edu/fatec/api/controller/coordenacao/HistoricoCoordController.java
+++ b/src/main/java/br/edu/fatec/api/controller/coordenacao/HistoricoCoordController.java
@@ -15,7 +15,6 @@ import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.layout.VBox;
-import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 
 import java.sql.SQLException;
@@ -38,10 +37,8 @@ public class HistoricoCoordController extends BaseController {
     @FXML private Label lblAlunoSelecionado;
     @FXML private Label lblVersaoSelecionada;
     @FXML private Label lblDataEnvio;
-    @FXML private VBox feedbackContainer;
     @FXML private VBox previewContainer;
 
-    private final JdbcFeedbackDao feedbackDao = new JdbcFeedbackDao();
     private final JdbcVersoesTrabalhoDao versoesDao = new JdbcVersoesTrabalhoDao();
     private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
 

--- a/src/main/java/br/edu/fatec/api/controller/orientador/HistoricoOrientadorController.java
+++ b/src/main/java/br/edu/fatec/api/controller/orientador/HistoricoOrientadorController.java
@@ -18,7 +18,6 @@ import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.layout.VBox;
-import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 
 import java.sql.SQLException;


### PR DESCRIPTION
📝 Descrição das Mudanças
Este PR corrige a renderização do Preview de Markdown nas telas de Histórico de Versões (Aluno, Orientador e Coordenador), que havia parado de funcionar após a migração para o JDK 21.

🐛 O Problema
O componente WebView do JavaFX 21 possui restrições de segurança/rede que impediam o carregamento da biblioteca externa marked.js (via CDN), deixando a tela de preview em branco.

🚀 A Solução
Renderização Nativa: Substituímos a dependência de JavaScript externo pela biblioteca Flexmark (Java). A conversão de Markdown para HTML agora é feita no backend, garantindo compatibilidade e funcionamento offline.

UX do Coordenador: A tela de histórico do Coordenador foi simplificada. Removemos a divisão com o código Markdown cru ("Modo Editor") para focar 100% na leitura do documento renderizado (Preview em tela cheia).

📂 Arquivos Afetados
HistoricoCoordController.java

HistoricoOrientadorController.java

HistoricoAlunoController.java