### PR TITLE
chore<untracked>: exclusão da visão em Markdown do orientador

### DIFF
--- a/src/main/java/br/edu/fatec/api/controller/orientador/HistoricoOrientadorController.java
+++ b/src/main/java/br/edu/fatec/api/controller/orientador/HistoricoOrientadorController.java
@@ -42,7 +42,6 @@ public class HistoricoOrientadorController extends BaseController {
     @FXML private TableColumn<AlunoTableItem, String> colNome;
     @FXML private TextField txtBuscaAluno;
     @FXML private ListView<HistoricoItemDTO> listVersions;
-    @FXML private TextArea txtMarkdownSource;
     @FXML private WebView webPreview;
     @FXML private Label lblAlunoSelecionado;
     @FXML private Label lblVersaoSelecionada;
@@ -246,7 +245,6 @@ public class HistoricoOrientadorController extends BaseController {
 
         // Limpar seleções e filtros anteriores
         listVersions.getItems().clear();
-        txtMarkdownSource.clear();
         webPreview.getEngine().loadContent("");
         feedbackContainer.setVisible(false);
         feedbackContainer.setManaged(false);
@@ -306,10 +304,7 @@ public class HistoricoOrientadorController extends BaseController {
     private void exibirVersao(VersaoHistoricoDTO versao) {
         lblVersaoSelecionada.setText(versao.versao());
         lblDataEnvio.setText(versao.createdAt().format(dateFormatter));
-        txtMarkdownSource.setText(versao.conteudoMd());
         renderMarkdown(versao.conteudoMd());
-        txtMarkdownSource.setVisible(true);
-        txtMarkdownSource.setManaged(true);
         webPreview.setVisible(true);
         webPreview.setManaged(true);
 
@@ -326,9 +321,6 @@ public class HistoricoOrientadorController extends BaseController {
     private void exibirFeedback(Mensagem msg) {
         lblVersaoSelecionada.setText("Feedback (Chat)");
         lblDataEnvio.setText(msg.getCreatedAt().format(dateFormatter));
-        txtMarkdownSource.setText("");
-        txtMarkdownSource.setVisible(false);
-        txtMarkdownSource.setManaged(false);
         webPreview.setVisible(false);
         webPreview.setManaged(false);
         renderMarkdown("### Este item é um feedback (mensagem de chat)\n\nNão há preview de TG associado.");

--- a/src/main/resources/views/orientador/Historico.fxml
+++ b/src/main/resources/views/orientador/Historico.fxml
@@ -105,21 +105,11 @@
                                 </VBox>
                             </HBox>
 
-                            <SplitPane orientation="HORIZONTAL" dividerPositions="0.5" VBox.vgrow="ALWAYS">
-                                <VBox spacing="4.0">
-                                    <Label text="Markdown" style="-fx-font-size: 13px; -fx-font-weight: 600;"/>
-                                    <TextArea fx:id="txtMarkdownSource" editable="false" wrapText="true"
-                                              VBox.vgrow="ALWAYS"
-                                              style="-fx-font-family: 'Courier New', monospace; -fx-font-size: 12px;
-                                                     -fx-border-color: #d6d6d6; -fx-border-width: 1; -fx-border-radius: 4;
-                                                     -fx-control-inner-background: #f8f9fa;"/>
-                                </VBox>
-                                <VBox spacing="4.0">
-                                    <Label text="Preview" style="-fx-font-size: 13px; -fx-font-weight: 600;"/>
-                                    <WebView fx:id="webPreview" VBox.vgrow="ALWAYS"
-                                             style="-fx-border-color: #d6d6d6; -fx-border-width: 1; -fx-border-radius: 4;"/>
-                                </VBox>
-                            </SplitPane>
+                            <VBox spacing="4.0" VBox.vgrow="ALWAYS">
+                                <Label text="Visualização do Trabalho" style="-fx-font-size: 13px; -fx-font-weight: 600;"/>
+                                <WebView fx:id="webPreview" VBox.vgrow="ALWAYS"
+                                         style="-fx-border-color: #d6d6d6; -fx-border-width: 1; -fx-border-radius: 4;"/>
+                            </VBox>
 
                             <VBox fx:id="feedbackContainer" spacing="4.0" managed="false" visible="false"
                                   style="-fx-background-color: #d1ecf1; -fx-border-color: #17a2b8;


### PR DESCRIPTION
📝 O que foi feito?
* Este PR simplifica a interface da tela de Histórico de Versões do Orientador, removendo a visualização do código-fonte Markdown (lado esquerdo) e priorizando a visualização do Preview Renderizado (lado direito).

🎯 Motivo
* Melhoria de UX: A exibição do código cru (Markdown) dividia a tela e reduzia o espaço de leitura. O foco do Orientador deve ser a leitura do trabalho renderizado.

Consistência: Alinha o layout com a tela do Coordenador, que recebeu a mesma melhoria recentemente.

🛠️ Alterações Técnicas
* FXML (Historico.fxml): Removido o SplitPane horizontal que dividia a tela. O WebView (Preview) agora ocupa toda a largura disponível. A caixa de feedbacks (feedbackContainer) foi preservada abaixo do preview.

Controller (HistoricoOrientadorController.java): Removidos os elementos @FXML e a lógica de manipulação do campo de texto txtMarkdownSource, que não é mais utilizado.